### PR TITLE
Update es_systems_steam2.cfg

### DIFF
--- a/steam/shortcuts/es_configs/es_systems_steam2.cfg
+++ b/steam/shortcuts/es_configs/es_systems_steam2.cfg
@@ -9,7 +9,7 @@
         <path>/userdata/roms/steam2</path>
         <extension>.sh</extension>
         <command>%ROM%</command>
-        <platform>pc</platform>
+        <platform>windows</platform>
         <theme>steam</theme>
         <emulators>
             <emulator name="steam2">


### PR DESCRIPTION
The "pc" settings searches for dos games on screescraper. "windows" allows a far more effective scraping. See my other correction on batocera: https://github.com/batocera-linux/batocera.linux/pull/11002