### PR TITLE
Use latest version of Moonlight

### DIFF
--- a/moonlight/moonlight.sh
+++ b/moonlight/moonlight.sh
@@ -16,7 +16,7 @@
 #--------------------------------------------------------------------- 
 #       DEFINE APP INFO >>
 APPNAME=moonlight 
-APPLINK=$(curl https://github.com/moonlight-stream/moonlight-qt/releases/tag/v4.3.1 | grep AppImage | sed 's,^.*href=",,g' | cut -d \" -f1)
+APPLINK=$(curl -L https://github.com/moonlight-stream/moonlight-qt/releases/latest | grep AppImage | sed 's,^.*href=",,g' | cut -d \" -f1)
 APPHOME="github.com/moonlight-stream"
 #---------------------------------------------------------------------
 #       DEFINE LAUNCHER COMMAND >>


### PR DESCRIPTION
Currently Moonlight version is fixed to 4.3.1, however 6.0.0 is out, with tons of improvements. This update ensures that installer script always points to the latest release. 

For those who are curious, `-L` option allows curl to follow redirects, so `releases/latest` redirects to the latest release url, e.g. `releases/tag/v6.0.0`.